### PR TITLE
Refresh page after server restart

### DIFF
--- a/inject-script.js
+++ b/inject-script.js
@@ -1,6 +1,21 @@
 (() => {
+	const startPing = () => {
+		const interval = setInterval(() => {
+			fetch(`/php-ts-dev-ping?${Date.now()}`, { cache: "no-store" })
+				.then((res) => {
+					if (res.status < 500) {
+						clearInterval(interval);
+						location.reload();
+					}
+				})
+				.catch(() => {});
+		}, 1000);
+	};
+
 	const ws = new WebSocket("/php-ts-dev-ws");
 	ws.onmessage = () => {
 		location.reload();
 	};
+	ws.onclose = startPing;
+	ws.onerror = startPing;
 })();

--- a/inject-script.js
+++ b/inject-script.js
@@ -18,5 +18,4 @@
 		location.reload();
 	};
 	ws.onclose = ping;
-	ws.onerror = ping;
 })();

--- a/inject-script.js
+++ b/inject-script.js
@@ -1,21 +1,22 @@
 (() => {
-	const startPing = () => {
-		const interval = setInterval(() => {
-			fetch(`/php-ts-dev-ping?${Date.now()}`, { cache: "no-store" })
-				.then((res) => {
-					if (res.status < 500) {
-						clearInterval(interval);
-						location.reload();
-					}
-				})
-				.catch(() => {});
-		}, 1000);
+	const ping = () => {
+		fetch(`/php-ts-dev-ping?${Date.now()}`, { cache: "no-store" })
+			.then((res) => {
+				if (res.status < 500) {
+					location.reload();
+				} else {
+					setTimeout(ping, 1000);
+				}
+			})
+			.catch(() => {
+				setTimeout(ping, 1000);
+			});
 	};
 
 	const ws = new WebSocket("/php-ts-dev-ws");
 	ws.onmessage = () => {
 		location.reload();
 	};
-	ws.onclose = startPing;
-	ws.onerror = startPing;
+	ws.onclose = ping;
+	ws.onerror = ping;
 })();


### PR DESCRIPTION
## Summary
- Reload the page only after the server responds without 5xx errors when the WebSocket connection drops
- Periodically ping `php-ts-dev` backend to detect server availability and trigger a refresh

## Testing
- `npx prettier inject-script.js --write`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c11aeadb488325953b2842cbf11f1d